### PR TITLE
Include time stamps corresponding to time of emission for Solar RVs

### DIFF
--- a/barycorrpy/sample_script.py
+++ b/barycorrpy/sample_script.py
@@ -90,7 +90,7 @@ def run_sample():
 
             result7 = utc_tdb.JDUTC_to_SolarEmissionTDB(JDUTC=2458000, obsname='KPNO')
 
-            if np.isclose(a=result7[0], b=2458000.00662602, atol=1e-7, rtol=0):
+            if np.isclose(a=result7[0], b=2457999.99497543, atol=1e-7, rtol=0):
                 a.append('result7')
                 b+=1
 

--- a/barycorrpy/sample_script.py
+++ b/barycorrpy/sample_script.py
@@ -88,10 +88,15 @@ def run_sample():
                 a.append('result6')
                 b+=1
 
+            result7 = utc_tdb.JDUTC_to_SolarEmissionTDB(JDUTC=2458000, obsname='KPNO')
 
-            if b==7:
-                print('***********SUCCESS**************\nAll barycentric correction velocities match expected values to 1 cm/s\n')
+            if np.isclose(a=result7[0], b=2458000.00662602, atol=1e-7, rtol=0):
+                a.append('result7')
+                b+=1
+
+            if b==8:
+                print('***********SUCCESS**************\nAll barycentric correction velocities,  and time stamp conversions match expected values.\n')
             else:
-                print('{} out of 7 results match. Compare outputs vs those on the github wiki. Check others - \n'.format(b,a))
+                print('{} out of 8 results match. Compare outputs vs those on the github wiki. Check others - \n'.format(b,a))
 
-            return result, result2, result3, result4, JDUTCMID, warning4, status4, corr_time, result5, result6
+            return result, result2, result3, result4, JDUTCMID, warning4, status4, corr_time, result5, result6, result7

--- a/barycorrpy/tests/test_barycorrpy.py
+++ b/barycorrpy/tests/test_barycorrpy.py
@@ -82,8 +82,10 @@ class Barycorrpy_tests(unittest.TestCase):
         result6 = get_BC_vel(JDUTC=2458000, lat=-30.169138888, longi=-70.805888, alt=2379.5, zmeas=0.0, SolSystemTarget='Sun')
         self.assertTrue(np.isclose(a = result6[0], b = 819.4474, atol = 1e-2, rtol = 0))
 
+    def test_SolarEmissionTDB(self):
 
-
+        result7 = utc_tdb.JDUTC_to_SolarEmissionTDB(JDUTC=2458000, obsname='KPNO')
+        self.assertTrue(np.isclose(a=result7[0], b=2458000.00662602, atol=1e-7, rtol=0))
 
 
 

--- a/barycorrpy/tests/test_barycorrpy.py
+++ b/barycorrpy/tests/test_barycorrpy.py
@@ -85,7 +85,7 @@ class Barycorrpy_tests(unittest.TestCase):
     def test_SolarEmissionTDB(self):
 
         result7 = utc_tdb.JDUTC_to_SolarEmissionTDB(JDUTC=2458000, obsname='KPNO')
-        self.assertTrue(np.isclose(a=result7[0], b=2458000.00662602, atol=1e-7, rtol=0))
+        self.assertTrue(np.isclose(a=result7[0], b=2457999.99497543, atol=1e-7, rtol=0))
 
 
 

--- a/barycorrpy/utc_tdb.py
+++ b/barycorrpy/utc_tdb.py
@@ -517,8 +517,14 @@ def _JDUTC_to_SolarEmissionTDB(JDUTC, loc,
     ephemeris='de430', leap_dir=os.path.join(os.path.dirname(__file__),'data'), leap_update=True):
 
     '''
-    Time conversion between JDUTC to BJDTDB. See Eastman et al. (2010)
-    This code is precise to about 200 us.
+    Based on Eastman et al. 2010, but converts JDUTC to JDTDB, and then moves the 
+    clock to the time of emission from the heliocenter.
+    This is to serve as a time stamp for the solar RVs as observed by PRV spectrographs. 
+    It includes the JDUTC to JDTDB time conversion,  as well as the light travel time from observatory 
+    to solar center and the Einstein delay.
+    
+    Precision has not been explicity tested.
+
 
     See JDUTC_to_BJDTDB() for parameter description.
 

--- a/barycorrpy/utc_tdb.py
+++ b/barycorrpy/utc_tdb.py
@@ -229,7 +229,7 @@ def JDUTC_to_BJDTDB(JDUTC,
 
     '''
     Time conversion between JDUTC to BJDTDB. See Eastman et al. (2010)
-    This code is precise to about 200 us.
+    This code is precise to about 10 ms.
 
     Calling procedure for JDUTC_to_BJDTDB. Accepts vector time object (i.e., multiple observation JD values).
 
@@ -352,7 +352,7 @@ def _JDUTC_to_BJDTDB(JDUTC,
 
     '''
     Time conversion between JDUTC to BJDTDB. See Eastman et al. (2010)
-    This code is precise to about 200 us.
+    This code is precise to about 10 ms
 
     See JDUTC_to_BJDTDB() for parameter description.
 
@@ -422,7 +422,7 @@ def JDUTC_to_SolarEmissionTDB(JDUTC,
     '''
     Based on Eastman et al. 2010, but converts JDUTC to JDTDB, and then moves the 
     clock to the time of emission from the heliocenter.
-    This is to serve as a time stamp for the solar RVs as observed by PRV spectrographs. 
+    This is to serve as a time stamp for the solar RVs as observed by PRV spectrographs (Wright and Kanodia 2020).
     It includes the JDUTC to JDTDB time conversion,  as well as the light travel time from observatory 
     to solar center and the Einstein delay.
     
@@ -519,7 +519,7 @@ def _JDUTC_to_SolarEmissionTDB(JDUTC, loc,
     '''
     Based on Eastman et al. 2010, but converts JDUTC to JDTDB, and then moves the 
     clock to the time of emission from the heliocenter.
-    This is to serve as a time stamp for the solar RVs as observed by PRV spectrographs. 
+    This is to serve as a time stamp for the solar RVs as observed by PRV spectrographs (Wright and Kanodia 2020).
     It includes the JDUTC to JDTDB time conversion,  as well as the light travel time from observatory 
     to solar center and the Einstein delay.
     

--- a/barycorrpy/utc_tdb.py
+++ b/barycorrpy/utc_tdb.py
@@ -559,7 +559,7 @@ def _JDUTC_to_SolarEmissionTDB(JDUTC, loc,
 
     PosVector_SolEarth, PosMag_SolEarth, PosHat_SolEarth = CalculatePositionVector(r1=PosVector_SolSSB, r2=PosVector_EarthSSB)
 
-    geo_corr_SSB = PosMag_SolEarth/c 
+    geo_corr_SSB =  - PosMag_SolEarth/c 
     
     # calculate the Einstein delay relative to the geocenter
     # (TDB accounts for Einstein delay to geocenter)


### PR DESCRIPTION
Add a new function JDUTC_to_SolarEmissionTDB() to convert the JDUTC time of observation to the TDB time scale time of emission from the Sun. 

Also include this in the unit test and run_sample()