### PR TITLE
V0.4.1 deprecate leap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# barycorrpy (v0.4.0)
+# barycorrpy (v0.4.1)
 
 ### Please join the google group for updates regarding bug reports, new versions etc:
 To sign up for updates, please join the Google Group linked here -

--- a/barycorrpy/SolarSystemBC.py
+++ b/barycorrpy/SolarSystemBC.py
@@ -35,9 +35,9 @@ def SolarBarycentricCorrection(JDUTC, loc, zmeas=0, ephemeris='de430', leap_dir=
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir: Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory. [DEPRECATED >= v0.4.0]
+                script directory. [Not used with versions >= v0.4.0]
         leap_update: If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
+                If False, then will just give a warning message. Default is True. [Not used with versions >= v0.4.0]
 
         predictive : If True, then instead of returning v_true, returns v_predicted.
         Default: False, and return is v_true from Wright and Eastman (2014)
@@ -164,9 +164,9 @@ def ReflectedLightBarycentricCorrection(SolSystemTarget, JDUTC, loc, zmeas=0, Ho
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir: Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory. [DEPRECATED >= v0.4.0]
+                script directory. [Not used with versions >= v0.4.0]
         leap_update: If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
+                If False, then will just give a warning message. Default is True. [Not used with versions >= v0.4.0]
 
         predictive : If True, then instead of returning v_true, returns v_predicted.
             Default: False, and return is v_true from Wright and Eastman (2014)

--- a/barycorrpy/SolarSystemBC.py
+++ b/barycorrpy/SolarSystemBC.py
@@ -35,9 +35,9 @@ def SolarBarycentricCorrection(JDUTC, loc, zmeas=0, ephemeris='de430', leap_dir=
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir: Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory.
+                script directory. [DEPRECATED >= v0.4.0]
         leap_update: If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                If False, then will just give a warning message. Default is True.
+                If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
 
         predictive : If True, then instead of returning v_true, returns v_predicted.
         Default: False, and return is v_true from Wright and Eastman (2014)
@@ -65,7 +65,7 @@ def SolarBarycentricCorrection(JDUTC, loc, zmeas=0, ephemeris='de430', leap_dir=
 
     # Convert times to obtain TDB and TT
 
-    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC, fpath=leap_dir, leap_update=leap_update)
+    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC)
 
     ##### NUTATION, PRECESSION, ETC. #####
 
@@ -164,9 +164,9 @@ def ReflectedLightBarycentricCorrection(SolSystemTarget, JDUTC, loc, zmeas=0, Ho
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir: Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory.
+                script directory. [DEPRECATED >= v0.4.0]
         leap_update: If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                If False, then will just give a warning message. Default is True.
+                If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
 
         predictive : If True, then instead of returning v_true, returns v_predicted.
             Default: False, and return is v_true from Wright and Eastman (2014)
@@ -199,7 +199,7 @@ def ReflectedLightBarycentricCorrection(SolSystemTarget, JDUTC, loc, zmeas=0, Ho
 
 
     # Convert times to obtain TDB and TT
-    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC, fpath=leap_dir, leap_update=leap_update)
+    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC)
 
 
     # Need dictionary object for HORIZONS call

--- a/barycorrpy/__init__.py
+++ b/barycorrpy/__init__.py
@@ -6,4 +6,4 @@ from .sample_script import *
 from .barycorrpy import get_BC_vel, BCPy, exposure_meter_BC_vel
 from .SolarSystemBC import SolarBarycentricCorrection, ReflectedLightBarycentricCorrection
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/barycorrpy/barycorrpy.py
+++ b/barycorrpy/barycorrpy.py
@@ -64,10 +64,10 @@ def get_BC_vel(JDUTC,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory. [DEPRECATED >= v0.4.0]
+                script directory. [Not used with versions >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
                       If False, then will just give a warning message. Default is True.
-                      [DEPRECATED >= v0.4.0]
+                      [Not used with versions >= v0.4.0]
         SolSystemTarget : When running barycentric correction for a stellar target, Target = None. Default value = None
                 To correct for Solar RV observations set Target = 'Sun', for reflected light observations, see below.
 
@@ -77,8 +77,8 @@ def get_BC_vel(JDUTC,
                     2. loc
                     3. zmeas
                     4. ephemeris
-                    5. leap_dir [DEPRECATED >= v0.4.0]
-                    6. leap_update [DEPRECATED >= v0.4.0]
+                    5. leap_dir [Not used with versions >= v0.4.0]
+                    6. leap_update [Not used with versions >= v0.4.0]
                     7. predictive
 
                 For Reflected light observations:
@@ -410,9 +410,9 @@ def exposure_meter_BC_vel(JDUTC, expmeterflux,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-            script directory. [DEPRECATED >= v0.4.0]
+            script directory. [Not used with versions >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
+                      If False, then will just give a warning message. Default is True. [Not used with versions >= v0.4.0]
         SolSystemTarget : When running barycentric correction for a stellar target, Target = None. Default value = None
                 To correct for Solar RV observations set Target = 'Sun', for reflected light observations, see below.
 
@@ -422,8 +422,8 @@ def exposure_meter_BC_vel(JDUTC, expmeterflux,
                     2. loc
                     3. zmeas
                     4. ephemeris
-                    5. leap_dir [DEPRECATED >= v0.4.0]
-                    6. leap_update [DEPRECATED >= v0.4.0]
+                    5. leap_dir [Not used with versions >= v0.4.0]
+                    6. leap_update [Not used with versions >= v0.4.0]
                     7. predictive
 
                 For Reflected light observations:

--- a/barycorrpy/barycorrpy.py
+++ b/barycorrpy/barycorrpy.py
@@ -64,9 +64,10 @@ def get_BC_vel(JDUTC,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-                script directory.
+                script directory. [DEPRECATED >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
                       If False, then will just give a warning message. Default is True.
+                      [DEPRECATED >= v0.4.0]
         SolSystemTarget : When running barycentric correction for a stellar target, Target = None. Default value = None
                 To correct for Solar RV observations set Target = 'Sun', for reflected light observations, see below.
 
@@ -76,8 +77,8 @@ def get_BC_vel(JDUTC,
                     2. loc
                     3. zmeas
                     4. ephemeris
-                    5. leap_dir
-                    6. leap_update
+                    5. leap_dir [DEPRECATED >= v0.4.0]
+                    6. leap_update [DEPRECATED >= v0.4.0]
                     7. predictive
 
                 For Reflected light observations:
@@ -181,15 +182,6 @@ def get_BC_vel(JDUTC,
     else:
         loc = EarthLocation.from_geodetic(longi, lat, height=alt)
 
-    # check if we need to update the leap second file up front using the maximum
-    # of the JDUTC array. Then we turn it off regardless of what the user had set
-    if leap_update:
-        maxutc = max(JDUTC)
-        # Call function to check leap second file and find offset between UTC and TAI.
-        tai_utc, warning1, error1 = utc_tdb.leap_manage(utctime=maxutc, fpath=leap_dir, leap_update=leap_update)
-        warning += warning1
-        error += error1
-
     # STELLAR TARGET #
     if SolSystemTarget is None:
         # Running correction for stellar observation
@@ -218,7 +210,7 @@ def get_BC_vel(JDUTC,
             a = BCPy(JDUTC=jdutc,
                      zmeas=zm,
                      loc=loc,
-                     ephemeris=ephemeris, leap_dir=leap_dir, leap_update=False,
+                     ephemeris=ephemeris, 
                      predictive=predictive, **star_output)
 
             vel.append(a[0])
@@ -230,7 +222,7 @@ def get_BC_vel(JDUTC,
         vel = []
         for jdutc,zm in zip(JDUTC,np.repeat(zmeas,len(JDUTC.flatten())/np.size(zmeas))):
             a = SolarBarycentricCorrection(JDUTC=jdutc, loc=loc, zmeas=zm,
-                    ephemeris=ephemeris, leap_dir=leap_dir, leap_update=False, predictive=predictive)
+                    ephemeris=ephemeris, predictive=predictive)
             vel.append(a[0])
             warning.append(a[1])
             error.append(a[2])
@@ -241,7 +233,7 @@ def get_BC_vel(JDUTC,
         vel = []
         for jdutc,zm in zip(JDUTC,np.repeat(zmeas,len(JDUTC.flatten())/np.size(zmeas))):
             a = ReflectedLightBarycentricCorrection(SolSystemTarget=SolSystemTarget, JDUTC=jdutc, loc=loc, zmeas=zm, HorizonsID_type=HorizonsID_type,
-                    ephemeris=ephemeris, leap_dir=leap_dir, leap_update=False, predictive=predictive)
+                    ephemeris=ephemeris, predictive=predictive)
             vel.append(a[0])
             warning.append(a[1])
             error.append(a[2])
@@ -271,7 +263,7 @@ def BCPy(JDUTC,
     '''
 
     # Convert times to obtain TDB and TT
-    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC, fpath=leap_dir, leap_update=leap_update)
+    JDTDB, JDTT, warning, error = utc_tdb.JDUTC_to_JDTDB(JDUTC)
 
     ##### NUTATION, PRECESSION, ETC. #####
 
@@ -418,9 +410,9 @@ def exposure_meter_BC_vel(JDUTC, expmeterflux,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is
-            script directory.
+            script directory. [DEPRECATED >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True.
+                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
         SolSystemTarget : When running barycentric correction for a stellar target, Target = None. Default value = None
                 To correct for Solar RV observations set Target = 'Sun', for reflected light observations, see below.
 
@@ -430,8 +422,8 @@ def exposure_meter_BC_vel(JDUTC, expmeterflux,
                     2. loc
                     3. zmeas
                     4. ephemeris
-                    5. leap_dir
-                    6. leap_update
+                    5. leap_dir [DEPRECATED >= v0.4.0]
+                    6. leap_update [DEPRECATED >= v0.4.0]
                     7. predictive
 
                 For Reflected light observations:
@@ -510,7 +502,7 @@ def exposure_meter_BC_vel(JDUTC, expmeterflux,
     vel,warning,status = get_BC_vel(JDUTC=JDUTC,
                                 starname=starname,hip_id=hip_id,ra=ra,dec=dec,epoch=epoch,pmra=pmra,pmdec=pmdec,px=px,
                                 obsname=obsname,lat=lat,longi=longi,alt=alt,
-                                rv=rv,zmeas=zmeas,ephemeris=ephemeris,leap_dir=leap_dir,leap_update=leap_update,
+                                rv=rv,zmeas=zmeas,ephemeris=ephemeris,
                                 SolSystemTarget=SolSystemTarget, HorizonsID_type=HorizonsID_type, predictive=predictive)
 
 

--- a/barycorrpy/utc_tdb.py
+++ b/barycorrpy/utc_tdb.py
@@ -182,7 +182,7 @@ def JDUTC_to_JDTDB(utctime,leap_update=True,fpath=fpath):
         utctime : Enter UTC time as Astropy Time Object. In UTC Scale.
         fpath : Path to where the file would be saved. Default is script directory.
         leap_update : If True, when the leap second file is more than 6 months old it will attempt to download a new one.
-                      If False, then will just give a warning message.  Default is True.
+                      If False, then will just give a warning message.  Default is True. [DEPRECATED >= v0.4.0]
 
     OUTPUT:
         JDTDB : Julian Date Barycentric Dynamic Time (Astropy Time object)
@@ -246,9 +246,9 @@ def JDUTC_to_BJDTDB(JDUTC,
                     ['de432s','de430',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
-        leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory.
+        leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory. [DEPRECATED >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True.
+                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
 
     OUTPUT:
         corr_time : BJDTDB time
@@ -314,7 +314,7 @@ def JDUTC_to_BJDTDB(JDUTC,
     for jdutc in JDUTC:
         a = _JDUTC_to_BJDTDB(JDUTC=jdutc,
                  loc=loc,
-                 ephemeris=ephemeris, leap_dir=leap_dir, leap_update=leap_update,**star_output)
+                 ephemeris=ephemeris, **star_output)
         corr_time.append(a[0])
         warning.append(a[1])
         error.append(a[2])
@@ -345,7 +345,7 @@ def _JDUTC_to_BJDTDB(JDUTC,
     '''
 
     # Convert times to obtain TDB and TT
-    JDTDB, JDTT, warning, error = JDUTC_to_JDTDB(JDUTC, fpath=leap_dir, leap_update=leap_update)
+    JDTDB, JDTT, warning, error = JDUTC_to_JDTDB(JDUTC)
     clock_corr = (JDTDB.jd - JDUTC.jd) * 86400.
 
     ##### NUTATION, PRECESSION, ETC. #####
@@ -434,8 +434,9 @@ def JDUTC_to_HJDTDB(JDUTC,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory.
+        [DEPRECATED >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True.
+                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
 
     OUTPUT:
         corr_time : BJDTDB time
@@ -513,7 +514,7 @@ def _JDUTC_to_HJDTDB(JDUTC, loc,
     '''
 
     # Convert times to obtain TDB and TT
-    JDTDB, JDTT, warning, error = JDUTC_to_JDTDB(JDUTC, fpath=leap_dir, leap_update=leap_update)
+    JDTDB, JDTT, warning, error = JDUTC_to_JDTDB(JDUTC)
     clock_corr = (JDTDB.jd - JDUTC.jd) * 86400.
 
     ##### NUTATION, PRECESSION, ETC. #####

--- a/barycorrpy/utc_tdb.py
+++ b/barycorrpy/utc_tdb.py
@@ -182,7 +182,7 @@ def JDUTC_to_JDTDB(utctime,leap_update=True,fpath=fpath):
         utctime : Enter UTC time as Astropy Time Object. In UTC Scale.
         fpath : Path to where the file would be saved. Default is script directory.
         leap_update : If True, when the leap second file is more than 6 months old it will attempt to download a new one.
-                      If False, then will just give a warning message.  Default is True. [DEPRECATED >= v0.4.0]
+                      If False, then will just give a warning message.  Default is True. [Not used with versions >= v0.4.0]
 
     OUTPUT:
         JDTDB : Julian Date Barycentric Dynamic Time (Astropy Time object)
@@ -246,9 +246,9 @@ def JDUTC_to_BJDTDB(JDUTC,
                     ['de432s','de430',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
-        leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory. [DEPRECATED >= v0.4.0]
+        leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory. [Not used with versions >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
+                      If False, then will just give a warning message. Default is True. [Not used with versions >= v0.4.0]
 
     OUTPUT:
         corr_time : BJDTDB time
@@ -434,9 +434,9 @@ def JDUTC_to_HJDTDB(JDUTC,
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de423_for_mercury_and_venus/de423.bsp',
                     'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de405.bsp']
         leap_dir : Directory where leap seconds file will be saved and maintained (STRING). Eg. '/Users/abc/home/savehere/'. Default is script directory.
-        [DEPRECATED >= v0.4.0]
+        [Not used with versions >= v0.4.0]
         leap_update : If True, when the leap second file is more than 6 months old will attempt to download a new one.
-                      If False, then will just give a warning message. Default is True. [DEPRECATED >= v0.4.0]
+                      If False, then will just give a warning message. Default is True. [Not used with versions >= v0.4.0]
 
     OUTPUT:
         corr_time : BJDTDB time

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='barycorrpy',
-      version='0.4.0',
+      version='0.4.1',
       description='Barycentric Velocity correction at 1 cm/s level',
       long_description=readme(),
       url='https://github.com/shbhuk/barycorrpy',


### PR DESCRIPTION
Deprecate the `leap_update` and `leap_dir` keyword, since the leap second updates are now done by Astropy instead (Issue #40).