### PR TITLE
Handle astropy deprecation warning by importing erfa instead of astropy.__erfa

### DIFF
--- a/barycorrpy/PINT_erfautils.py
+++ b/barycorrpy/PINT_erfautils.py
@@ -4,10 +4,7 @@ from __future__ import division
 import numpy as np
 import astropy.units as u
 import datetime
-try:
-    import astropy.erfa as erfa
-except ImportError:
-    import astropy._erfa as erfa
+import erfa
 import astropy.table as table
 from astropy.time import Time
 from astropy.utils.iers import conf,IERS_A, IERS_A_URL, IERS_B, IERS_B_URL, IERS


### PR DESCRIPTION
removed a warning: 

"AstropyDeprecationWarning: The private astropy._erfa module has been made into its own package, pyerfa, which is a dependency of astropy and can be imported directly using "import erfa" [astropy._erfa]"

That appeared after importing the following:

from barycorrpy import utc_tdb
from barycorrpy import get_BC_vel