### PR TITLE
v0.4.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# barycorrpy (v0.4.1)
+# barycorrpy (v0.4.2)
 
 ### Please join the google group for updates regarding bug reports, new versions etc:
 To sign up for updates, please join the Google Group linked here -

--- a/barycorrpy/PINT_erfautils.py
+++ b/barycorrpy/PINT_erfautils.py
@@ -4,10 +4,7 @@ from __future__ import division
 import numpy as np
 import astropy.units as u
 import datetime
-try:
-    import astropy.erfa as erfa
-except ImportError:
-    import astropy._erfa as erfa
+import erfa
 import astropy.table as table
 from astropy.time import Time
 from astropy.utils.iers import conf,IERS_A, IERS_A_URL, IERS_B, IERS_B_URL, IERS

--- a/barycorrpy/__init__.py
+++ b/barycorrpy/__init__.py
@@ -6,4 +6,4 @@ from .sample_script import *
 from .barycorrpy import get_BC_vel, BCPy, exposure_meter_BC_vel
 from .SolarSystemBC import SolarBarycentricCorrection, ReflectedLightBarycentricCorrection
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/barycorrpy/barycorrpy.py
+++ b/barycorrpy/barycorrpy.py
@@ -228,7 +228,7 @@ def get_BC_vel(JDUTC,
             error.append(a[2])
 
     else:
-        print("Reflected light observations of solar system objects include complexities not accounted for in this calculation, such as rotation, phase effects, and finite source effects.  See Wright & Kanodia (2020)")
+        # print("Reflected light observations of solar system objects include complexities not accounted for in this calculation, such as rotation, phase effects, and finite source effects.  See Wright & Kanodia (2020)")
         warning+=["Reflected light observations of solar system objects include complexities not accounted for in this calculation, such as rotation, phase effects, and finite source effects.  See Wright & Kanodia (2020)"]
         vel = []
         for jdutc,zm in zip(JDUTC,np.repeat(zmeas,len(JDUTC.flatten())/np.size(zmeas))):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='barycorrpy',
-      version='0.4.1',
+      version='0.4.2',
       description='Barycentric Velocity correction at 1 cm/s level',
       long_description=readme(),
       url='https://github.com/shbhuk/barycorrpy',


### PR DESCRIPTION
1. Remove print message for warning in reflected light calculations. Instead use standard warning variable.
2. Use separate erfa package instead of astropy.erfa