### PR TITLE
Bug fix and add warning to reflected light code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# barycorrpy (v0.4.2)
+# barycorrpy (v0.4.3)
 
 ### Please join the google group for updates regarding bug reports, new versions etc:
 To sign up for updates, please join the Google Group linked here -

--- a/barycorrpy/SolarSystemBC.py
+++ b/barycorrpy/SolarSystemBC.py
@@ -218,7 +218,8 @@ def ReflectedLightBarycentricCorrection(SolSystemTarget, JDUTC, loc, zmeas=0, Ho
     # except ValueError:
     #     warning+= ['Unable to use Vector query for Horizons search using exact observatory coordinates, reverting to using Geocenter. ']
     try:
-        TargetObj1 = Horizons(id=SolSystemTarget, location='399', epochs=JDTDB, id_type=HorizonsID_type).vectors()
+        TargetObj1 = Horizons(id=SolSystemTarget, location='399', epochs=JDTDB.jd, id_type=HorizonsID_type).vectors()
+        warning += ['Queried {} from Horizons'.format(TargetObj1['targetname'][0])]
     except Exception as e:
         print(e)
         raise Exception("Error with Horizons call, id={}, location='399' (Geocenter), epochs={}, id_type={}".format(SolSystemTarget, JDTDB, HorizonsID_type))
@@ -228,7 +229,7 @@ def ReflectedLightBarycentricCorrection(SolSystemTarget, JDUTC, loc, zmeas=0, Ho
 
     # Subtract light time and find pos and vel for target wrt SSB
     TargetObjTime = JDTDB - (EarthTargetLightTravel)
-    TargetObj2 = Horizons(id=SolSystemTarget, location='@0', epochs=TargetObjTime, id_type=HorizonsID_type)
+    TargetObj2 = Horizons(id=SolSystemTarget, location='@0', epochs=TargetObjTime.jd, id_type=HorizonsID_type)
     TargetVectors = TargetObj2.vectors(refplane='earth')
     TargetSSBLightTravel = TargetVectors['lighttime'][0] #days
 

--- a/barycorrpy/__init__.py
+++ b/barycorrpy/__init__.py
@@ -6,4 +6,4 @@ from .sample_script import *
 from .barycorrpy import get_BC_vel, BCPy, exposure_meter_BC_vel
 from .SolarSystemBC import SolarBarycentricCorrection, ReflectedLightBarycentricCorrection
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='barycorrpy',
-      version='0.4.2',
+      version='0.4.3',
       description='Barycentric Velocity correction at 1 cm/s level',
       long_description=readme(),
       url='https://github.com/shbhuk/barycorrpy',


### PR DESCRIPTION
1. Query Horizons using TDB JD float instead of using Astropy Time Object
2. Add a warning based on the target name queried from Horizons. Can use this to help troubleshoot if the correct target was queried, especially in light of the majorbody/smallbody ambiguity.